### PR TITLE
Implements Splash screen "the right way"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name="cz.devconf2017.Splash">
+            android:name="cz.devconf2017.Splash"
+            android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/cz/devconf2017/Splash.java
+++ b/app/src/main/java/cz/devconf2017/Splash.java
@@ -4,34 +4,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
-/**
- * Created by jridky on 10.12.16.
- */
-
 public class Splash extends AppCompatActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstanceState){
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.splash);
-
-        Thread timerThread = new Thread(){
-            public void run(){
-                try{
-                    super.run();
-                    sleep(1500);
-                }catch(Exception e){
-                    e.printStackTrace();
-                }finally {
-                    Intent i = new Intent(Splash.this, MainActivity.class);
-                    if(getIntent().getExtras() != null) {
-                        i.putExtras(getIntent().getExtras());
-                    }
-                    startActivity(i);
-                    finish();
-                }
-            }
-        };
-        timerThread.start();
+        startActivity(new Intent(this, MainActivity.class));
+        finish();
     }
 }

--- a/app/src/main/res/drawable/background_splash.xml
+++ b/app/src/main/res/drawable/background_splash.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@color/primary_dark"/>
+
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/logonotify"/>
+    </item>
+
+</layer-list>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:windowBackground">@drawable/background_splash</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
The current implementation is widely not recommended. It forces the user to wait a few seconds that are not necessary to load the app. I ignore if this is the intended behaviour but I would suggest changing the implementation: leaving the splash only for the loading time and allowing the user to open the app as quickly as possible.
This is a very extended example of a “well made” splash: https://www.bignerdranch.com/blog/splash-screens-the-right-way/